### PR TITLE
Fix: Leading and trailing whitespace in the content of POM XML elements ...

### DIFF
--- a/jip/maven.py
+++ b/jip/maven.py
@@ -25,7 +25,7 @@ import os
 import sys
 import re
 from xml.etree import ElementTree
-from string import Template
+from string import Template, whitespace
 
 from . import logger, repos_manager, cache_manager
 
@@ -85,6 +85,11 @@ class Artifact(object):
         artifact = Artifact(group, artifact, version)
         return artifact
 
+
+class WhitespaceNormalizer(ElementTree.TreeBuilder):   # The target object of the parser
+     def data(self, data):
+         data=data.strip(whitespace)         #strip whitespace at start and end of string
+         super(WhitespaceNormalizer,self).data(data)  
     
 class Pom(object):
     def __init__(self, pom_string):
@@ -98,7 +103,7 @@ class Pom(object):
         if self.eletree is None:
             ## we use this dirty method to remove namesapce attribute so that elementtree will use default empty namespace
             pom_string = re.sub(r"<project(.|\s)*?>", '<project>', self.pom_string, 1)
-            self.eletree = ElementTree.fromstring(pom_string)
+            self.eletree = ElementTree.XML(pom_string, ElementTree.XMLParser(target=WhitespaceNormalizer()))
         return self.eletree
 
     def get_parent_pom(self):


### PR DESCRIPTION
...could lead to failure with a KeyError in get_dependencies.

Assuming whitespace is not meant to be preserverd in the process of parsing the POM document (or the modified pom_string), we alter the parsing process by explicitly supplying a parser that has a specialised TreeBuilder object as target. The WhitespaceNormalizer(ElementTree.TreeBuilder) discards leading and trailing whitespace from element content.
This way only 1 place has to be changed to possibly affect all POM properties that could suffer from such problems.

E.g.

> jip install de.tudarmstadt.ukp.dkpro.core:de.tudarmstadt.ukp.dkpro.core.io.conll-asl:1.7.0

Produces the following:
Traceback (most recent call last):
  File "/project/software/jython-env/bin/jip", line 8, in <module>
    sys.exit(
  File "/project/software/jython-env/Lib/site-packages/jip-0.8.3-py2.7.egg/jip/main.py", line 62, in main
    commands[cmd](**args)
  File "/project/software/jython-env/Lib/site-packages/jip-0.8.3-py2.7.egg/jip/commands.py", line 46, in wrapper
    func(*args, **kwargs)
  File "/project/software/jython-env/Lib/site-packages/jip-0.8.3-py2.7.egg/jip/commands.py", line 171, in install
    _install([artifact], options=options)
  File "/project/software/jython-env/Lib/site-packages/jip-0.8.3-py2.7.egg/jip/commands.py", line 144, in _install
    download_list = _resolve_artifacts(artifacts, exclusions)
  File "/project/software/jython-env/Lib/site-packages/jip-0.8.3-py2.7.egg/jip/commands.py", line 129, in _resolve_artifacts
    more_dependencies = pom_obj.get_dependencies()
  File "/project/software/jython-env/Lib/site-packages/jip-0.8.3-py2.7.egg/jip/maven.py", line 210, in get_dependencies
    version = dep_mgmt[(group_id, artifact_id)][0]
KeyError: ('de.tudarmstadt.ukp.dkpro.core', '\n\t\t\t\tde.tudarmstadt.ukp.dkpro.core.api.io-asl\n\t\t\t')