### PR TITLE
 	Fix: Reference ${project.parent.version} not resolved in dependecy/version spec.

### DIFF
--- a/jip/maven.py
+++ b/jip/maven.py
@@ -67,8 +67,8 @@ class Artifact(object):
     def __repr__(self):
         return self.__str__()
 
-#    def __hash__(self):
-#        return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
+    def __hash__(self):
+        return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
 
     def is_snapshot(self):
         return self.version.find('SNAPSHOT') > 0

--- a/jip/maven.py
+++ b/jip/maven.py
@@ -67,8 +67,8 @@ class Artifact(object):
     def __repr__(self):
         return self.__str__()
 
-    def __hash__(self):
-        return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
+#    def __hash__(self):
+#        return self.group.__hash__()*13+self.artifact.__hash__()*7+self.version.__hash__()
 
     def is_snapshot(self):
         return self.version.find('SNAPSHOT') > 0
@@ -251,9 +251,11 @@ class Pom(object):
         if groupId is None:
             groupId = eletree.findtext('parent/groupId')
 
-        properties["project.groupId"] = groupId
+        properties["project.parent.version"] = eletree.findtext('parent/version')
+        properties["project.parent.groupId"] = eletree.findtext('parent/groupId')
+        properties["project.groupId"] = self.__resolve_placeholder(groupId, properties)
         properties["project.artifactId"] = artifactId
-        properties["project.version"] = version
+        properties["project.version"] = self.__resolve_placeholder(version, properties)
 
         properties["pom.groupId"] = groupId
         properties["pom.artifactId"] = artifactId


### PR DESCRIPTION
Hi,

there was a problem with POMs containing dependency specs of the following kind:

  ```      
        <dependency>
            <groupId>org.apache.uima</groupId>
            <artifactId>uimaj-core</artifactId>
            <version>${project.parent.version}</version>
            <scope>compile</scope>
        </dependency>
```

The reference `${project.parent.version}` would not be resolved. 

Steps to reproduce:
`jip install org.apache.uima:uimaj-tools:2.7.0`

Result:
> jip [Checking] pom file http://repo1.maven.org/maven2/org/apache/uima/uimaj-tools/2.7.0/uimaj-tools-2.7.0.pom
> jip [Checking] pom file http://repo1.maven.org/maven2/org/apache/uima/uimaj-cpe/${project.parent.version}/uimaj-cpe-${project.parent.version}.pom
> jip [Skipped] Pom file not found at http://repo1.maven.org/maven2/org/apache/uima/uimaj-cpe/${project.parent.version}/uimaj-cpe-${project.parent.version}.pom
> jip [Error] Artifact not found: org.apache.uima:uimaj-cpe:${project.parent.version}
