### PR TITLE
Allow the version of an artifact to be a variable

### DIFF
--- a/jip/maven.py
+++ b/jip/maven.py
@@ -47,12 +47,12 @@ class Artifact(object):
 
     def to_maven_name(self, ext):
         group = self.group.replace('.', '/')
-        return "{}/{}/{}/{}-{}.{}".format(group, self.artifact, self.version, self.artifact, self.version, ext)
+        return "%s/%s/%s/%s-%s.%s" % (group, self.artifact, self.version, self.artifact, self.version, ext)
 
     def to_maven_snapshot_name(self, ext):
         group = self.group.replace('.', '/')
         version_wo_snapshot = self.version.replace('-SNAPSHOT', '')
-        return "{}/{}/{}/{}-{}-{}-{}.{}".format(group, self.artifact, self.version, self.artifact, version_wo_snapshot,
+        return "%s/%s/%s/%s-%s-%s-%s.%s" % (group, self.artifact, self.version, self.artifact, version_wo_snapshot,
                 self.timestamp, self.build_number, ext)
 
     def __eq__(self, other):
@@ -62,7 +62,7 @@ class Artifact(object):
             return False
 
     def __str__(self):
-        return "{}:{}:{}".format(self.group, self.artifact, self.version)
+        return "%s:%s:%s" % (self.group, self.artifact, self.version)
 
     def __repr__(self):
         return self.__str__()

--- a/jip/util.py
+++ b/jip/util.py
@@ -69,9 +69,12 @@ def download(url, target, async=False, close_target=False, quiet=True):
 def download_string(url):
     import requests
     source = requests.get(url, headers={ 'User-Agent': JIP_USER_AGENT})
-    data = source.text
-    source.close()
-    return data
+    if source.status_code == 200:
+        data = source.text
+        source.close()
+        return data
+    else:
+        return False
 
 class DownloadThreadPool(object):
     def __init__(self, size=3):
@@ -107,13 +110,12 @@ def get_virtual_home():
     else:
         ## fail back to use current directory
         JYTHON_HOME = os.getcwd()
-    return JYTHON_HOME            
+    return JYTHON_HOME
 
 def get_lib_path():
-    JYTHON_HOME = get_virtual_home()        
+    JYTHON_HOME = get_virtual_home()
     DEFAULT_JAVA_LIB_PATH = os.path.join(JYTHON_HOME, 'javalib')
 
     if not os.path.exists(DEFAULT_JAVA_LIB_PATH):
         os.mkdir(DEFAULT_JAVA_LIB_PATH)
-    return DEFAULT_JAVA_LIB_PATH        
-
+    return DEFAULT_JAVA_LIB_PATH


### PR DESCRIPTION
The following changes are introduced:
 * If a package is not found in one repo (status 404) try the next repo in config
 * Repos config name changed to `.jip_config`
 * If the version of an Artifact is a variable `${version}` check the properties tag in the pom for the proper version