### PR TITLE
Update download_string in util.py

### DIFF
--- a/jip/util.py
+++ b/jip/util.py
@@ -70,7 +70,7 @@ def download_string(url):
     import requests
     source = requests.get(url, headers={ 'User-Agent': JIP_USER_AGENT})
     if source.status_code == 200:
-        data = source.text
+        data = source.content
         source.close()
         return data
     else:


### PR DESCRIPTION
Platform : Windows

Using jython and jip.embed require(), I had a problem updating maven packages having utf8 characters within their pom file.
The error message was :

Traceback (most recent call last):
  File "<somescript>.py", line 10, in <module>
    require('<sompackage>')
  File "C:\jython2.7.0\Lib\site-packages\jip\embed.py", line 38, in require
    artifact_set = _resolve_artifacts([artifact])
  File "C:\jython2.7.0\Lib\site-packages\jip\commands.py", line 109, in _resolve
_artifacts
    pominfo = _find_pom(artifact)
  File "C:\jython2.7.0\Lib\site-packages\jip\commands.py", line 86, in _find_pom
    cache_manager.put_artifact_pom(artifact, pom)
  File "C:\jython2.7.0\Lib\site-packages\jip\cache.py", line 90, in put_artifact
_pom
    self.cache.put_pom(artifact, data)
  File "C:\jython2.7.0\Lib\site-packages\jip\cache.py", line 65, in put_pom
    f.write(data)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 2706-2707: ordinal not in range(128)

I traced it back to the download function where the binary content is more interesting than the "string".
The real problem seems to lie within the requests library which doesn't return correct encoding for content of type : text\xml but still this patch makes the downloading of content encoding agnostic.

It solved my problem.