### PR TITLE
Add support for profile os activation of properties.

### DIFF
--- a/jip/maven.py
+++ b/jip/maven.py
@@ -22,6 +22,7 @@
 
 
 import os
+import platform
 import sys
 import re
 from xml.etree import ElementTree
@@ -272,6 +273,27 @@ class Pom(object):
         properties["pom.groupId"] = groupId
         properties["pom.artifactId"] = artifactId
         properties["pom.version"] = version
+        
+        system = platform.system()
+        if system == "Java":
+            release, vendor, vminfo, osinfo = platform.java_ver()
+            system = osinfo[0]
+        
+        ## translation table.
+        maven_os_families = {
+        "Windows 8.1" : "windows",
+        "nt" : "windows"
+        }
+        
+        system = maven_os_families[system]
+        
+        ## pom profiles
+        for profile in eletree.findall("./profiles/profile"):
+            family_rule = profile.find("./activation/os/family")
+            if (family_rule is not None) and (family_rule.text == system):
+                for profile_property in profile.findall("./properties//*"):
+                    properties[profile_property.tag] = profile_property.text
+        
         self.properties = properties
         return properties
 


### PR DESCRIPTION
When reading a pom file, the maven.py function get_properties() also check for current os and uses local dictionary and the palatform library to assige desired properties when parsing the pom file.

Maven values for os family :
https://maven.apache.org/enforcer/enforcer-rules/requireOS.html

Further maintenance / improvement can be done using the translation table named : "maven_os_families".