### PR TITLE
Fixed requests' json response reading in both Python 2.x and 3.x

### DIFF
--- a/jip/util.py
+++ b/jip/util.py
@@ -70,7 +70,7 @@ def download_string(url):
     import requests
     source = requests.get(url, headers={ 'User-Agent': JIP_USER_AGENT})
     if source.status_code == 200:
-        data = source.content
+        data = source.text
         source.close()
         return data
     else:

--- a/jip/util.py
+++ b/jip/util.py
@@ -68,10 +68,10 @@ def download(url, target, async=False, close_target=False, quiet=True):
 
 def download_string(url):
     import requests
-    source = requests.get(url, headers={ 'User-Agent': JIP_USER_AGENT})
-    if source.status_code == 200:
-        data = source.text
-        source.close()
+    response = requests.get(url, headers={ 'User-Agent': JIP_USER_AGENT})
+    if response.status_code == 200:
+        data = response.text
+        response.close()
         return data
     else:
         return False


### PR DESCRIPTION
According the documentation at http://docs.python-requests.org/en/master/api/#requests.Response.text

This should make the CI happy also with Python 3.4.